### PR TITLE
Feature/185 origin host ip and connection type

### DIFF
--- a/doc/freediameter.conf.sample
+++ b/doc/freediameter.conf.sample
@@ -287,9 +287,11 @@ TLS_Cred = "/etc/ssl/certs/freeDiameter.pem", "/etc/ssl/private/freeDiameter.key
 #  ConnectTo = "2001:200:903:2::202:1";
 #  TLS_Prio = "NORMAL";
 #  Realm = "realm.net"; # Reject the peer if it does not advertise this realm.
+#  PeerType = "server"; # Defaults to client type otherwise. We don't send CERs to peers marked as 'server'
 # Examples:
 #ConnectPeer = "aaa.wide.ad.jp";
 #ConnectPeer = "old.diameter.serv" { TcTimer = 60; TLS_old_method; No_SCTP; Port=3868; } ;
+#ConnectPeer = "old.diameter.serv" { TcTimer = 60; TLS_old_method; No_SCTP; Port=3868; PeerType = "server"; } ;
 
 
 ##############################################################

--- a/doc/freediameter.conf.sample
+++ b/doc/freediameter.conf.sample
@@ -78,6 +78,13 @@
 #ListenOn = "2001:200:903:2::202:1";
 #ListenOn = "fe80::21c:5ff:fe98:7d62%eth0";
 
+# Specify which addresses are included in CER Host-IP-Address
+# AVPs. The default behaviour includes all addresses available.
+# If we wanted to only include addresses "1.1.1.1", "2.2.2.2"
+# but NOT "3.3.3.3" then we would include the following into
+# the conf file:
+#CerHostIpWhitelist = "1.1.1.1"
+#CerHostIpWhitelist = "2.2.2.2"
 
 ##############################################################
 ##  Server configuration

--- a/include/freeDiameter/libfdcore.h
+++ b/include/freeDiameter/libfdcore.h
@@ -184,6 +184,8 @@ struct fd_config {
 	uint32_t	 cnf_orstateid;	/* The value to use in Origin-State-Id, default to random value */
 	struct dictionary *cnf_dict;	/* pointer to the global dictionary */
 	struct fifo	  *cnf_main_ev;	/* events for the daemon's main (struct fd_event items) */
+
+	struct fd_list cer_host_ip_whitelist;	/* only include Host-IP-Address AVPs that have the following endpoints in CER */
 };
 extern struct fd_config *fd_g_config; /* The pointer to access the global configuration, initalized in main */
 

--- a/include/freeDiameter/libfdcore.h
+++ b/include/freeDiameter/libfdcore.h
@@ -298,6 +298,7 @@ struct peer_info {
 		int		pic_twtimer; 	/* use this value for TwTimer instead of global, if != 0 */
 		
 		char *		pic_priority;	/* Priority string for GnuTLS if we don't use the default */
+		int cnf_peer_type_server; /* If peer is a server we don't send a CER */
 		
 	} config;	/* Configured data (static for this peer entry) */
 	

--- a/libfdcore/config.c
+++ b/libfdcore/config.c
@@ -66,6 +66,7 @@ int fd_conf_init()
 	fd_g_config->cnf_qin_limit = 20;
 	fd_g_config->cnf_qout_limit = 30;
 	fd_g_config->cnf_qlocal_limit = 25;
+	fd_list_init(&fd_g_config->cer_host_ip_whitelist, NULL);
 	fd_list_init(&fd_g_config->cnf_endpoints, NULL);
 	fd_list_init(&fd_g_config->cnf_apps, NULL);
 	#ifdef DISABLE_SCTP

--- a/libfdcore/fdd.l
+++ b/libfdcore/fdd.l
@@ -270,6 +270,7 @@ nomatch:
 (?i:"LoadExtension")	{ return LOADEXT; }
 (?i:"ConnectPeer")	{ return CONNPEER; }
 (?i:"ConnectTo")	{ return CONNTO; }
+(?i:"PeerType")		{ return PEERTYPE; }
 (?i:"No_TLS")		{ return NOTLS; }
 (?i:"TLS_Cred")		{ return TLS_CRED; }
 (?i:"TLS_CA")		{ return TLS_CA; }

--- a/libfdcore/fdd.l
+++ b/libfdcore/fdd.l
@@ -260,6 +260,7 @@ nomatch:
 (?i:"OutgoingQueueLimit")	{ return QOUTLIMIT; }
 (?i:"LocalQueueLimit")	{ return QLOCALLIMIT; }
 (?i:"ListenOn")		{ return LISTENON; }
+(?i:"CerHostIpWhitelist")		{ return CERHOSTIPWHITELIST; }
 (?i:"ThreadsPerServer")	{ return THRPERSRV; }
 (?i:"ProcessingPeersPattern")	{ return PROCESSINGPEERSPATTERN; }
 (?i:"ProcessingPeersMinimum")	{ return PROCESSINGPEERSMINIMUM; }

--- a/libfdcore/fdd.y
+++ b/libfdcore/fdd.y
@@ -113,6 +113,7 @@ struct peer_info fddpi;
 %token		QOUTLIMIT
 %token		QLOCALLIMIT
 %token		LISTENON
+%token		CERHOSTIPWHITELIST
 %token		THRPERSRV
 %token		PROCESSINGPEERSPATTERN
 %token		PROCESSINGPEERSMINIMUM
@@ -147,6 +148,7 @@ conffile:		/* Empty is OK -- for simplicity here, we reject in daemon later */
 			| conffile sec3436
 			| conffile sctpstreams
 			| conffile listenon
+			| conffile cerhostipwhitelist
 			| conffile thrpersrv
 			| conffile processingpeerspattern
 			| conffile processingpeersminimum
@@ -253,6 +255,21 @@ listenon:		LISTENON '=' QSTRING ';'
 				ret = getaddrinfo($3, NULL, &hints, &ai);
 				if (ret) { yyerror (&yylloc, conf, gai_strerror(ret)); YYERROR; }
 				CHECK_FCT_DO( fd_ep_add_merge( &conf->cnf_endpoints, ai->ai_addr, ai->ai_addrlen, EP_FL_CONF ), YYERROR );
+				freeaddrinfo(ai);
+				free($3);
+			}
+			;
+
+cerhostipwhitelist:		CERHOSTIPWHITELIST '=' QSTRING ';'
+			{
+				struct addrinfo hints, *ai;
+				int ret;
+				
+				memset(&hints, 0, sizeof(hints));
+				hints.ai_flags = AI_PASSIVE | AI_NUMERICHOST;
+				ret = getaddrinfo($3, NULL, &hints, &ai);
+				if (ret) { yyerror (&yylloc, conf, gai_strerror(ret)); YYERROR; }
+				CHECK_FCT_DO( fd_ep_add_merge( &conf->cer_host_ip_whitelist, ai->ai_addr, ai->ai_addrlen, EP_FL_CONF ), YYERROR );
 				freeaddrinfo(ai);
 				free($3);
 			}

--- a/libfdcore/fdd.y
+++ b/libfdcore/fdd.y
@@ -123,6 +123,7 @@ struct peer_info fddpi;
 %token		LOADEXT
 %token		CONNPEER
 %token		CONNTO
+%token		PEERTYPE
 %token		TLS_CRED
 %token		TLS_CA
 %token		TLS_CRL
@@ -632,6 +633,16 @@ peerparams:		/* empty */
 				CHECK_FCT_DO( fd_ep_add_merge( &fddpi.pi_endpoints, ai->ai_addr, ai->ai_addrlen, EP_FL_CONF | (disc ?: EP_ACCEPTALL) ), YYERROR );
 				free($4);
 				freeaddrinfo(ai);
+			}
+			| peerparams PEERTYPE '=' QSTRING ';'
+			{
+				if ((0 == strcmp("server", $4)) ||
+				    (0 == strcmp("Server", $4)))
+				{
+					fddpi.config.cnf_peer_type_server = 1;
+				} else {
+					fddpi.config.cnf_peer_type_server = 0;
+				}
 			}
 			;
 

--- a/libfdcore/p_ce.c
+++ b/libfdcore/p_ce.c
@@ -37,6 +37,8 @@
 
 /* This file contains code to handle Capabilities Exchange messages (CER and CEA) and election process */
 
+static uint8_t skip_host_ip(struct fd_endpoint* ep);
+
 /* Save a connection as peer's principal */
 static int set_peer_cnx(struct fd_peer * peer, struct cnxctx **cnx)
 {
@@ -109,6 +111,12 @@ static int add_CE_info(struct msg *msg, struct cnxctx * cnx, int isi_tls, int is
 	/* Add the AVP(s) -- not sure what is the purpose... We could probably only add the primary one ? */
 	for (li = fd_g_config->cnf_endpoints.next; li != &fd_g_config->cnf_endpoints; li = li->next) {
 		struct fd_endpoint * ep = (struct fd_endpoint *)li;
+
+		/* This is gross but it does the job, needed here as CERs
+		 * aren't piped through extensions before sending */
+		if (skip_host_ip(ep)) {
+			continue;
+		}
 		CHECK_FCT( fd_msg_avp_new ( dictobj, 0, &avp ) );
 		CHECK_FCT( fd_msg_avp_value_encode ( &ep->ss, avp ) );
 		CHECK_FCT( fd_msg_avp_add( msg, MSG_BRW_LAST_CHILD, avp ) );
@@ -1146,4 +1154,23 @@ int fd_p_ce_handle_newCER(struct msg ** msg, struct fd_peer * peer, struct cnxct
 	}
 				
 	return 0;
+}
+
+/* Returns 1 if the whitelist exists AND provided endpoint wasn't found in the whitelist, returns 0 otherwise */
+static uint8_t skip_host_ip(struct fd_endpoint* ep)
+{
+	struct fd_list *li = NULL;
+	uint8_t match = 0;
+	uint8_t whitelist_exists = fd_g_config->cer_host_ip_whitelist.next != &fd_g_config->cer_host_ip_whitelist;
+
+	for (li = fd_g_config->cer_host_ip_whitelist.next; li != &fd_g_config->cer_host_ip_whitelist; li = li->next) {
+		struct fd_endpoint * config_ep = (struct fd_endpoint *)li;
+		
+		if (ep->sin.sin_addr.s_addr == config_ep->sin.sin_addr.s_addr) {
+			match = 1;
+			break;
+		}
+	}
+
+	return ((1 == whitelist_exists) && (0 == match));
 }

--- a/libfdcore/p_psm.c
+++ b/libfdcore/p_psm.c
@@ -792,7 +792,15 @@ psm_loop:
 			case STATE_WAITCNXACK_ELEC:
 			case STATE_WAITCNXACK:
 				LOG_D("%s: Connection established, %s", peer->p_hdr.info.pi_diamid, fd_cnx_getid(cnx));
-				fd_p_ce_handle_newcnx(peer, cnx);
+				
+				/* This is gross but it does the job, we don't 
+				 * want to send a CER if peer is a server */
+				if (1 == peer->p_hdr.info.config.cnf_peer_type_server) {
+					LOG_N("%s: Peer marked as a server, waiting for CER...", peer->p_hdr.info.pi_diamid);
+				} else {
+					LOG_N("%s: Peer considered a client, sending CER...", peer->p_hdr.info.pi_diamid);
+					fd_p_ce_handle_newcnx(peer, cnx);
+				}
 				break;
 
 			default:

--- a/recompile.sh
+++ b/recompile.sh
@@ -1,0 +1,4 @@
+cd fDbuild
+cmake ../
+make install
+cd -

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+# /usr/local/bin/freeDiameterd -c /etc/freeDiameter/freeDiameter.conf
+/usr/src/freeDiameter/fDbuild/freeDiameterd/freeDiameterd -c /etc/freeDiameter/freeDiameter.conf


### PR DESCRIPTION
@davidkneipp This includes all features specified in [issue 185](https://github.com/Omnitouch/Omnitouch_Core/issues/185).

OriginHostIp:

We can whitelist the IPs we advertise via the `CerHostIpWhitelist` config option. Heres the desc in `doc/freediameter.conf.sample`:
```
# Specify which addresses are included in CER Host-IP-Address
# AVPs. The default behaviour includes all addresses available.
# If we wanted to only include addresses "1.1.1.1", "2.2.2.2"
# but NOT "3.3.3.3" then we would include the following into
# the conf file:
#CerHostIpWhitelist = "1.1.1.1"
#CerHostIpWhitelist = "2.2.2.2"
```

connectionType:

We can specify a peer as a server in the config file. If a peer is labelled as a server we do not send a CER to it, instead we wait for a CER to be sent to us. The desc in `doc/freediameter.conf.sample` is the following:
```
#  PeerType = "server"; # Defaults to client type otherwise. We don't send CERs to peers marked as 'server'
```

An example of me using it is the following:
```
ConnectPeer = "omni-ryan-mme02.epc.mnc380.mcc313.3gppnetwork.org" {
   ConnectTo = "10.177.1.115";
   No_TLS; 
};

ConnectPeer = "omni-ryan-dra02.epc.mnc380.mcc313.3gppnetwork.org" {
    ConnectTo = "10.177.2.242";
    No_TLS;
    PeerType = "server";
};
```

In this case we immediately send a CER to the MME but we wait for a CER from the other DRA.